### PR TITLE
Before and after views are flipped

### DIFF
--- a/src/chrome/diff.ts
+++ b/src/chrome/diff.ts
@@ -107,13 +107,7 @@ export async function getFileDiff(
             filename
         )
         const before = await convert(kittycad, beforeBlob, extension)
-        const afterBlob = await downloadFile(
-            github,
-            owner,
-            repo,
-            sha,
-            filename
-        )
+        const afterBlob = await downloadFile(github, owner, repo, sha, filename)
         const after = await convert(kittycad, afterBlob, extension)
         return { before, after }
     }


### PR DESCRIPTION
Fixes #94 with a quick two-line change

Seems like I have spent too much time looking at existing commits and PRs I didn't have context on 🤦

The wrong order, that commit was adding an extrusion, not removing it
![image](https://user-images.githubusercontent.com/10795683/231759012-c32a0f02-92ce-424f-b08c-01bae1f28cc8.png)


The right order:
![image](https://user-images.githubusercontent.com/10795683/231759059-5265dd19-b7b3-439c-96af-c967d3d12951.png)

