### PR TITLE
Improve release process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,22 +25,6 @@ jobs:
 
             - run: yarn install
 
-            - name: Set release version to .json files and commit to main
-              if: github.event_name == 'release'
-              env:
-                BRANCH: main
-              run: |
-                  git fetch origin
-                  git checkout $BRANCH
-                  echo "$(jq --arg v "${RELEASE#v}" '.version=$v' package.json         --indent 4)" > package.json
-                  echo "$(jq --arg v "${RELEASE#v}" '.version=$v' public/manifest.json --indent 4)" > public/manifest.json
-                  git diff
-                  git add .
-                  git config user.name github-actions
-                  git config user.email github-actions@github.com
-                  git commit -m "Align versions with $RELEASE"
-                  git push origin $BRANCH
-
             - run: yarn build
 
             - run: yarn test

--- a/README.md
+++ b/README.md
@@ -48,3 +48,17 @@ If you aren’t satisfied with the build tool and configuration choices, you can
 Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
 
 You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
+
+## Release a new version
+
+1. Bump the versions in the source code by creating a new PR, committing the changes from
+
+```bash
+VERSION=x.y.z npm run bump
+```
+
+2. Merge the PR
+
+3. Create a new release and tag pointing to the bump version commit using semantic versioning `v{x}.{y}.{z}`
+
+A new Action should run, uploading artifacts to the release itself and to the Chrome Web Store at https://chrome.google.com/webstore/detail/kittycad-diff-viewer/gccpihmphokfjpohkmkbimnhhnlpmegp

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
         "build": "INLINE_RUNTIME_CHUNK=false craco build",
         "test": "react-scripts test",
         "e2e": "yarn build && yarn playwright test",
-        "eject": "react-scripts eject"
+        "eject": "react-scripts eject",
+        "bump": "echo \"$(jq --arg v \"$VERSION\" '.version=$v' package.json --indent 4)\" > package.json && echo \"$(jq --arg v \"$VERSION\" '.version=$v' public/manifest.json --indent 4)\" > public/manifest.json"
     },
     "eslintConfig": {
         "extends": [


### PR DESCRIPTION
Fixes #125

> Right now the two biggest problems following https://github.com/KittyCAD/diff-viewer-extension/issues/98
> 1. main needs to be manually unprotected to let the github action commit and push the version bump
> 2. since the release+tag is what starts the action, the version corresponding to the tag is wrong (the commit right after the tag fixes it)
>
> We can solve both by having a bump-version PR before we start the release, and remove the auto commit from the action itself