### PR TITLE
Enable pan (one-liner)

### DIFF
--- a/src/components/viewer/Controls.tsx
+++ b/src/components/viewer/Controls.tsx
@@ -21,7 +21,7 @@ export function Controls({ target, reference, onAltered }: ControlsProps) {
             ref={reference}
             target={target}
             args={[camera, gl.domElement]}
-            enablePan={false}
+            enablePan={true}
         />
     )
 }


### PR DESCRIPTION
Now that we have a Recenter button, I believe it's safe to give the user more control. Right-click-to-pan (three's default) is intuitive can be useful to inspect the part.